### PR TITLE
fix delete character from buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ It targets communication with embedded systems from remote terminal to quickly s
 * Written in C language (C99)
 * No dynamic allocation, maximum number of commands assigned at compile time
 * Highly configurable
-* Simple help-text with `cmd -v` option
+* Simple help-text with `cmd -h` option
 * User friendly MIT license
 
 ## Contribute

--- a/dev/main.c
+++ b/dev/main.c
@@ -3,6 +3,20 @@
 #include <string.h>
 #include <stdint.h>
 
+/**
+ * \brief           Reading one character at a time 
+ *
+ * This is useful to test the shell in a "raw" mode (non-canonical input)
+ * Please note that conio.h is a windows only header
+ */
+#ifndef LWSHELL_TEST_READ_SINGLE_CHAR
+#define LWSHELL_TEST_READ_SINGLE_CHAR           0
+#endif
+
+#if LWSHELL_TEST_READ_SINGLE_CHAR
+#include <conio.h>
+#endif
+
 void    example_minimal(void);
 
 int32_t
@@ -89,7 +103,13 @@ main(void) {
     printf("Start entering your command and press enter...\r\n");
     while (1) {
         char str[255];
+
+#if LWSHELL_TEST_READ_SINGLE_CHAR
+        str[0] = getch();
+        str[1] = '\0';
+#else
         fgets(str, sizeof(str), stdin);
+#endif
 
         /* Insert input to library */
         lwshell_input(str, strlen(str));

--- a/lwshell/src/lwshell/lwshell.c
+++ b/lwshell/src/lwshell/lwshell.c
@@ -285,8 +285,8 @@ lwshell_input(const void* in_data, size_t len) {
             case LWSHELL_ASCII_BACKSPACE: {
                 /* Try to delete character from buffer */
                 if (lw->buff_ptr > 0) {
-                    lw->buff[lw->buff_ptr] = '\0';
                     --lw->buff_ptr;
+                    lw->buff[lw->buff_ptr] = '\0';
                     LW_OUTPUT(lw, "\b \b");
                 }
                 break;


### PR DESCRIPTION
buff_ptr point to the end of the input buffer which is NULL, so it should be decreased before deleting the last character.
I added a test option to test it by using a non-canonical input mode