### PR TITLE
declare lwshell_cmd_t in header file

### DIFF
--- a/lwshell/src/include/lwshell/lwshell.h
+++ b/lwshell/src/include/lwshell/lwshell.h
@@ -93,6 +93,15 @@ typedef struct lwshell {
     char* argv[LWSHELL_CFG_MAX_CMD_ARGS];     /*!< Array of all arguments */
 } lwshell_t;
 
+/**
+ * \brief           Shell command structure
+ */
+typedef struct {
+    lwshell_cmd_fn fn; /*!< Command function to call on match */
+    const char* name;  /*!< Command name to search for match */
+    const char* desc;  /*!< Command description for help */
+} lwshell_cmd_t;
+
 lwshellr_t lwshell_init(void);
 lwshellr_t lwshell_set_output_fn(lwshell_output_fn out_fn);
 lwshellr_t lwshell_register_cmd(const char* cmd_name, lwshell_cmd_fn cmd_fn, const char* desc);

--- a/lwshell/src/lwshell/lwshell.c
+++ b/lwshell/src/lwshell/lwshell.c
@@ -58,15 +58,6 @@
 #define LW_OUTPUT(lw, str)
 #endif
 
-/**
- * \brief           Shell command structure
- */
-typedef struct {
-    lwshell_cmd_fn fn; /*!< Command function to call on match */
-    const char* name;  /*!< Command name to search for match */
-    const char* desc;  /*!< Command description for help */
-} lwshell_cmd_t;
-
 /* Array of all commands */
 static lwshell_cmd_t cmds[LWSHELL_CFG_MAX_CMDS];
 static size_t cmds_cnt;


### PR DESCRIPTION
Moving the struct to the header file would allow the application writer to declare their commands with it.

See: 
**https://github.com/Ballen7/money-printer/blob/dev/apps/tempo/src/console.c**