### PR TITLE
Removed duplicate variable reset

### DIFF
--- a/lwshell/src/lwshell/lwshell.c
+++ b/lwshell/src/lwshell/lwshell.c
@@ -109,7 +109,6 @@ prv_parse_input(lwshell_t* lwobj) {
         str = lwobj->buff;
 
         /* Process complete string */
-        lwobj->argc = 0;
         while (*str != '\0') {
             while (*str == ' ' && ++str) {} /* Remove leading spaces */
             if (*str == '\0') {


### PR DESCRIPTION
lwobj->argc (the counter for number of arguments about to be parsed) was cleared twice before starting the parsing loop.