### PR TITLE
chore: Run "c-code-style" astyle formatter on source/header files

### DIFF
--- a/dev/main.c
+++ b/dev/main.c
@@ -4,7 +4,7 @@
 #include "lwshell/lwshell.h"
 
 /**
- * \brief           Reading one character at a time 
+ * \brief           Reading one character at a time
  *
  * This is useful to test the shell in a "raw" mode (non-canonical input)
  * Please note that conio.h is a windows only header

--- a/lwshell/src/include/lwshell/lwshell_opt.h
+++ b/lwshell/src/include/lwshell/lwshell_opt.h
@@ -54,7 +54,7 @@ extern "C" {
 
 /**
  * \brief           Memory set function
- * 
+ *
  * \note            Function footprint is the same as \ref memset
  */
 #ifndef LWSHELL_MEMSET
@@ -63,7 +63,7 @@ extern "C" {
 
 /**
  * \brief           Memory copy function
- * 
+ *
  * \note            Function footprint is the same as \ref memcpy
  */
 #ifndef LWSHELL_MEMCPY
@@ -72,7 +72,7 @@ extern "C" {
 
 /**
  * \brief           Enables `1` or disables `0` dynamic command register with \ref lwshell_register_cmd or \ref lwshell_register_cmd_ex functions
- * 
+ *
  * \note            Set to `1` by default for backward compatibility
  * \sa              LWSHELL_CFG_USE_STATIC_COMMANDS
  */
@@ -82,12 +82,12 @@ extern "C" {
 
 /**
  * \brief           Enables `1` or disables `0` static command registration.
- * 
+ *
  * When enabled, a single register call is used where application
  * can pass constant array of the commands and respective callback functions.
- * 
+ *
  * This allows RAM reduction as lookup tables can be stored in the non-volatile memory
- * 
+ *
  * \note            Set to `0` by default for backward compatibility
  * \sa              LWSHELL_CFG_USE_DYNAMIC_COMMANDS
  */
@@ -97,7 +97,7 @@ extern "C" {
 
 /**
  * \brief           Maximum number of different dynamic registered commands
- * 
+ *
  * \warning         Deprecated and replaced with \ref LWSHELL_CFG_MAX_DYNAMIC_CMDS
  * \deprecated
  */
@@ -126,7 +126,7 @@ extern "C" {
 
 /**
  * \brief           Maximum characters for command name in bytes.
- * 
+ *
  * \note            Used only when \ref LWSHELL_CFG_USE_DYNAMIC_COMMANDS is enabled
  */
 #ifndef LWSHELL_CFG_MAX_CMD_NAME_LEN

--- a/lwshell/src/lwshell/lwshell.c
+++ b/lwshell/src/lwshell/lwshell.c
@@ -93,7 +93,7 @@ prv_parse_input(lwshell_t* lwobj) {
     size_t s_len;
     char* str;
 
-    /* 
+    /*
      * Check string length and compare with buffer pointer
      * Must be more than `1` character since we have to include end of line
      */
@@ -220,8 +220,8 @@ prv_parse_input(lwshell_t* lwobj) {
 #endif /* LWSHELL_CFG_USE_LIST_CMD */
         } else {
             LWSHELL_OUTPUT(lwobj, LWSHELL_CFG_USE_LIST_CMD
-                                      ? "Unknown command, use listcmd to list available commands\r\n"
-                                      : "Unknown command\r\n");
+                           ? "Unknown command, use listcmd to list available commands\r\n"
+                           : "Unknown command\r\n");
         }
     }
 }

--- a/tests/test.c
+++ b/tests/test.c
@@ -11,40 +11,40 @@ static const test_str_t commands[] = {
     {
         .command = "test 123 456 789\n",
         .args_list =
-            {
-                "test",
-                "123",
-                "456",
-                "789",
-            },
+        {
+            "test",
+            "123",
+            "456",
+            "789",
+        },
     },
     {
         .command = "test 123 longer text\n",
         .args_list =
-            {
-                "test",
-                "123",
-                "longer",
-                "text",
-            },
+        {
+            "test",
+            "123",
+            "longer",
+            "text",
+        },
     },
     {
         .command = "test 123 \"longer text\"\n",
         .args_list =
-            {
-                "test",
-                "123",
-                "longer text",
-            },
+        {
+            "test",
+            "123",
+            "longer text",
+        },
     },
     {
         .command = "test 123 \"longer text with \\\" quotes\"\n",
         .args_list =
-            {
-                "test",
-                "123",
-                "longer text with \\\" quotes",
-            },
+        {
+            "test",
+            "123",
+            "longer text with \\\" quotes",
+        },
     },
 };
 static uint32_t current_cmd_index;
@@ -52,10 +52,10 @@ static int failed = 0;
 
 /**
  * \brief           Test command function
- * 
- * \param           argc 
- * \param           argv 
- * \return          int32_t 
+ *
+ * \param           argc
+ * \param           argv
+ * \return          int32_t
  */
 int32_t
 prv_test_cmd(int32_t argc, char** argv) {
@@ -87,7 +87,7 @@ prv_test_cmd(int32_t argc, char** argv) {
 
 /**
  * \brief           Global test run function
- * 
+ *
  */
 int
 run_test(void) {


### PR DESCRIPTION
Ran `astyle --options="astyle-code-format.cfg" "./*.c,*.h"`. Caught some trailing whitespaces.